### PR TITLE
Replaces deprecated MinLength and MaxLength validators

### DIFF
--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -21,13 +21,11 @@
             <constraint name="NotBlank">
                 <option name="message">sylius.shipping_category.name.not_blank</option>
             </constraint>
-            <constraint name="MinLength">
-                <option name="limit">2</option>
-                <option name="message">sylius.shipping_category.name.min_length</option>
-            </constraint>
-            <constraint name="MaxLength">
-                <option name="limit">255</option>
-                <option name="message">sylius.shipping_category.name.max_length</option>
+            <constraint name="Length">
+                <option name="min">2</option>
+                <option name="max">255</option>
+                <option name="minMessage">sylius.shipping_category.name.min_length</option>
+                <option name="maxMessage">sylius.shipping_category.name.max_length</option>
             </constraint>
         </property>
     </class>
@@ -37,26 +35,22 @@
             <constraint name="NotBlank">
                 <option name="message">sylius.shipping_method.name.not_blank</option>
             </constraint>
-            <constraint name="MinLength">
-                <option name="limit">2</option>
-                <option name="message">sylius.shipping_method.name.min_length</option>
-            </constraint>
-            <constraint name="MaxLength">
-                <option name="limit">255</option>
-                <option name="message">sylius.shipping_method.name.max_length</option>
+            <constraint name="Length">
+                <option name="min">2</option>
+                <option name="max">255</option>
+                <option name="minMessage">sylius.shipping_method.name.min_length</option>
+                <option name="maxMessage">sylius.shipping_method.name.max_length</option>
             </constraint>
         </property>
         <property name="calculator">
             <constraint name="NotBlank">
                 <option name="message">sylius.shipping_method.calculator.not_blank</option>
             </constraint>
-            <constraint name="MinLength">
-                <option name="limit">2</option>
-                <option name="message">sylius.shipping_method.calculator.min_length</option>
-            </constraint>
-            <constraint name="MaxLength">
-                <option name="limit">255</option>
-                <option name="message">sylius.shipping_method.calculator.max_length</option>
+            <constraint name="Length">
+                <option name="min">2</option>
+                <option name="max">255</option>
+                <option name="minMessage">sylius.shipping_method.calculator.min_length</option>
+                <option name="maxMessage">sylius.shipping_method.calculator.max_length</option>
             </constraint>
         </property>
     </class>


### PR DESCRIPTION
Same modification as in AddrressingBundle.

BTW, I am replacing this validators because Sf2 warnings about "functions being deprecated and removed in future 2.3" is causing app in dev environment to time out with a "Maximum execution time of 60 seconds exceeded" in monolog.

Anyone else having this issue? 
